### PR TITLE
Fix Cloudflare email protection on SSH commands

### DIFF
--- a/index.html
+++ b/index.html
@@ -482,7 +482,7 @@ $ make
 
     <div class="span4">
       <h3 class="callout">Different username</h3>
-      <pre>$ mosh <b>potus@</b><i>ackbar.bls.gov</i></pre>
+      <pre>$ mosh <!--email_off--><b>potus@</b><i>ackbar.bls.gov</i><!--/email_off--></pre>
     </div>
 
     <div class="span4">
@@ -1082,7 +1082,7 @@ paper write that the attack is not applicable to OCB3.</p></dd>
   <dt>Q: How do I tell if mosh is working correctly?</dt>
 
   <dd>
-      <p>After you run <code>mosh user@server</code>, if successful you will be dropped into your login
+      <p>After you run <code>mosh <!--email_off-->user@server<!--/email_off--></code>, if successful you will be dropped into your login
       shell on the remote machine.
 
       If you want


### PR DESCRIPTION
The `user@host` parts of these commands are currently displayed as `[email protected]` when JavaScript is disabled because of email protection applied by Cloudflare. This change turns email protection off for the affected portions of the website.